### PR TITLE
Rework gamm check (and make miscellaneous tweaks)

### DIFF
--- a/R/dsm.var.gam.R
+++ b/R/dsm.var.gam.R
@@ -46,7 +46,7 @@
 #' detach("mexdolphins")
 #' }
 dsm.var.gam<-function(dsm.obj, pred.data, off.set,
-    seglen.varname = 'Effort', type.pred = "response") {
+                      seglen.varname = 'Effort', type.pred = "response") {
 
   # strip dsm class so we can use gam methods
   class(dsm.obj) <- class(dsm.obj)[class(dsm.obj)!="dsm"]

--- a/R/dsm.var.prop.R
+++ b/R/dsm.var.prop.R
@@ -55,7 +55,7 @@
 #' detach("mexdolphins")
 #' }
 dsm.var.prop<-function(dsm.obj, pred.data, off.set,
-    seglen.varname='Effort', type.pred="response") {
+                       seglen.varname='Effort', type.pred="response") {
 
   is.gamm <- FALSE
   # if we have a gamm, then just pull out the gam object

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,9 +1,23 @@
+dsm_env <- new.env(parent = emptyenv())
+
 .onAttach<-function(...){
+  
   # uses packageStartupMessage which can then be
-  # surpressed
+  # suppressed
   version <- utils::packageVersion("dsm")
   built <- utils::packageDescription("dsm",fields="Built")
-
   hello <- paste0("This is dsm ",version,"\nBuilt: ",built)
   packageStartupMessage(hello)
+  
+  # Check the MGCV version. If we do it here, there's no need to do it on every
+  # dsm() call.
+  mgcv.version <- as.numeric(strsplit(as.character(packageVersion("mgcv")),
+                                      "\\.")[[1]])
+  if(mgcv.version[1]<1 | (mgcv.version[2]<7 |
+     (mgcv.version[2]==7 & mgcv.version[3]<24))){
+    old_version <- TRUE
+  } else {
+    old_version <- FALSE
+  }
+  assign("old_mgcv", old_version, envir = dsm_env)
 }


### PR DESCRIPTION
This reworks the gamm version check to be done in .onLoad - since that means it only happens once per session, even if you call dsm() a gazillion times.

Also it fixes a couple of formatting inconsistencies. I don't have a great rationale for that beyond 'it was bugging me'